### PR TITLE
Fix: remove -ansi compile flag

### DIFF
--- a/src/motioncore/CMakeLists.txt
+++ b/src/motioncore/CMakeLists.txt
@@ -137,7 +137,7 @@ target_compile_features(motion PUBLIC cxx_std_20)
 target_compile_options(motion PRIVATE
         ${MOTION_EXTRA_FLAGS}
         -Wall -Wextra
-        -pedantic -ansi
+        -pedantic
         -maes -msse2 -msse4.1 -msse4.2 -mpclmul
         -ffunction-sections -march=native -ffast-math
         ${MOTION_VECT_COST_MODEL_GCC_FLAG}


### PR DESCRIPTION
MOTION suddenly stopped compiling for me after a system update with very weird errors such as 
```
error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
```
This was especially confusing, as I confirmed that `g++` is called with `std=gnu++20`. After much head scratching I noticed that `g++` is also called with the `-ansi` flag, which `In C++ mode, it is equivalent to -std=c++98.` (`man g++`).

My best guess is, that an update of `cmake` lead to the `std=` and `-ansi` options being emitted in a different order. For me, `-ansi` is emitted after `std=`, which seems to override it ([godbolt example](https://godbolt.org/z/sscjhreeG)). If the order is reversed, it works ([godbolt example](https://godbolt.org/z/zPEW1h439)).

This PR removes the `-ansi` flag as it does nothing at best, and causes the build to fail at worst.